### PR TITLE
Fix resource id according the new API changes

### DIFF
--- a/dataclips/api.py
+++ b/dataclips/api.py
@@ -106,7 +106,7 @@ class Client(object):
 
     def move_to_resource(self, slug, resource_id):
         post_data = {
-            "heroku_resource_id": resource_id
+            "heroku_id": resource_id
         }
 
         self._session.headers.update({

--- a/dataclips/move_all.py
+++ b/dataclips/move_all.py
@@ -22,7 +22,7 @@ def move_all(email, password, source_resource, destination_resource):
     source_dataclips_slugs = [
         dataclip['slug']
         for dataclip in heroku.get_all_dataclips()
-        if dataclip['heroku_resource_id'] == resources[source_resource]
+        if dataclip['heroku_id'] == resources[source_resource]
     ]
 
     for source_dataclip_slug in source_dataclips_slugs:


### PR DESCRIPTION
While moving dataclips, I noticed that the `heroku_resource_id` changed to `heroku_id`.
Tested afterwards, rest looks fine :)